### PR TITLE
Changes top menu links hover colours

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,13 +74,8 @@ img {
 	color: #fff;
 }
 
-#menu li:hover {
-	background-color: #800102;
-}
-
 #menu li:hover a {
-	background-color: #800102;
-	color: #FFFF00;
+	color: rgb(154, 205, 50);
 }
 
 #search_box {


### PR DESCRIPTION
I think it's more beautiful to don't have backgound colour and have a coloured-inverse colour for hovered links in top menu. (background removed from css properties and colour changed to: `yellowgreen`)
